### PR TITLE
fix addLiquidityNFTNFT functionality

### DIFF
--- a/src/Router/IMagicSwapV2Router.sol
+++ b/src/Router/IMagicSwapV2Router.sol
@@ -129,6 +129,8 @@ interface IMagicSwapV2Router is IUniswapV2Router01 {
     ///      `_vaultB.collection`, `_vaultB.tokenId` and `_vaultB.amount` must be of the same length.
     /// @param _vaultA vault data for NFTs to deposit as liquidity for first side
     /// @param _vaultB vault data for NFTs to deposit as liquidity for second side
+    /// @param _amountAMin minimum amount of token A to be deposited
+    /// @param _amountBMin minimum amount of token B to be deposited
     /// @param _to address that gets LP tokens
     /// @param _deadline transaction deadline
     /// @return amountA amount of token A added as liquidity
@@ -137,6 +139,8 @@ interface IMagicSwapV2Router is IUniswapV2Router01 {
     function addLiquidityNFTNFT(
         NftVaultLiquidityData calldata _vaultA,
         NftVaultLiquidityData calldata _vaultB,
+        uint256 _amountAMin,
+        uint256 _amountBMin,
         address _to,
         uint256 _deadline
     ) external returns (uint256 amountA, uint256 amountB, uint256 lpAmount);

--- a/src/Router/MagicSwapV2Router.sol
+++ b/src/Router/MagicSwapV2Router.sol
@@ -11,6 +11,7 @@ import "../UniswapV2/core/interfaces/IUniswapV2Pair.sol";
 
 contract MagicSwapV2Router is IMagicSwapV2Router, UniswapV2Router02 {
     uint256 public constant ONE = 1e18;
+    address public constant BURN_ADDRESS = address(0xdead);
 
     constructor(address _factory, address _WETH) UniswapV2Router02(_factory, _WETH) {}
 
@@ -150,7 +151,7 @@ contract MagicSwapV2Router is IMagicSwapV2Router, UniswapV2Router02 {
                 revert MagicSwapV2WrongAmountADeposited();
             }
             
-            TransferHelper.safeTransfer(address(_vaultA.token), address(0xdead), amountAMinted - amountA);
+            TransferHelper.safeTransfer(address(_vaultA.token), BURN_ADDRESS, amountAMinted - amountA);
         }
 
         if (amountBMinted != amountB) {
@@ -158,7 +159,7 @@ contract MagicSwapV2Router is IMagicSwapV2Router, UniswapV2Router02 {
                 revert MagicSwapV2WrongAmountBDeposited();
             }
 
-            TransferHelper.safeTransfer(address(_vaultB.token), address(0xdead), amountBMinted - amountB);
+            TransferHelper.safeTransfer(address(_vaultB.token), BURN_ADDRESS, amountBMinted - amountB);
         }
 
         address pair = UniswapV2Library.pairFor(factory, address(_vaultA.token), address(_vaultB.token));
@@ -260,11 +261,11 @@ contract MagicSwapV2Router is IMagicSwapV2Router, UniswapV2Router02 {
         amountB -= amountBurnedB;
 
         if (amountA > 0) {
-            TransferHelper.safeTransfer(address(_vaultA.token), _to, amountA);
+            TransferHelper.safeTransfer(address(_vaultA.token), BURN_ADDRESS, amountA);
         }
 
         if (amountB > 0) {
-            TransferHelper.safeTransfer(address(_vaultB.token), _to, amountB);
+            TransferHelper.safeTransfer(address(_vaultB.token), BURN_ADDRESS, amountB);
         }
 
         address pair = UniswapV2Library.pairFor(factory, address(_vaultA.token), address(_vaultB.token));


### PR DESCRIPTION
- Fixes the functionality of `addLiquidityNFTNFT` on the router contract. Previously, a user would have to deposit an exact multiple of the existing NFT-NFT pool reserves otherwise they'd get `UniswapV2RouterInsufficientAAmount` or `UniswapV2RouterInsufficientBAmount` errors. This change introduces new `_amountAMin` and `_amountBMin` parameters to be compatible with the UniswapV2 contract's `addLiquidity` function. Only the optimal amount of vault tokens will be sent to the liquidity pool while any leftovers will be burned.
- Updates the `removeLiquidityNFTNFT` function to also burn vault token dust instead of returning to user

### Example scenario

Current NFTA-NFTB pool reserves:
5 NFTA
10 NFTB

User wants to add liquidity with 5 NFTB. At current prices, that means they need to add 2.5 NFTA as well. Since the NFT can’t be fractional, we round up to 3 NFTA.

User selects 3 NFTA and 5 NFTB to deposit.

The router wants to make the most efficient deposit so it only sends 2.5 VaultNFTA to the pool, and there is 0.5 VaultNFTA left over in the router as dust, which is burned.